### PR TITLE
feat: metadata extraction step with research method classification

### DIFF
--- a/src/paper_scanner/cli/__init__.py
+++ b/src/paper_scanner/cli/__init__.py
@@ -18,6 +18,7 @@ STEP_REGISTRY_PATHS: Dict[str, str] = {
     "journal_screening": "paper_scanner.steps.journal_screening:JournalScreeningStep",
     "keyword_screening": "paper_scanner.steps.keyword_screening:KeywordScreeningStep",
     "llm_classification": "paper_scanner.steps.llm_classification:LLMClassificationStep",
+    "metadata_extraction": "paper_scanner.steps.metadata_extraction:MetadataExtractionStep",
     "load_files": "paper_scanner.steps.load_files:LoadFilesStep",
     "metadata_screening": "paper_scanner.steps.metadata_screening:MetadataScreeningStep",
     "paper": "paper_scanner.steps.paper:PaperStep",

--- a/src/paper_scanner/core/models.py
+++ b/src/paper_scanner/core/models.py
@@ -435,6 +435,26 @@ class Screening(BaseModel):
 
 
 # ============================================================================
+# RESEARCH METHOD CLASSIFICATION MODEL
+# ============================================================================
+
+class ResearchMethodClassification(BaseModel):
+    """Research method classification from LLM metadata extraction."""
+
+    empirical: bool = Field(description="Whether the paper is empirical (vs theoretical/conceptual)")
+    approach: Optional[str] = Field(
+        default=None,
+        description="Research approach: quantitative, qualitative, or mixed",
+    )
+    industry: Optional[str] = Field(
+        default=None,
+        description="Industry sector or domain the research applies to",
+    )
+
+    metadata: Optional[ProcessingMetadata] = None
+
+
+# ============================================================================
 # CAMO MODEL
 # ============================================================================
 
@@ -707,6 +727,12 @@ class Paper(BaseModel):
     # ========================================
 
     pdf_info: Optional[PDFInfo] = None
+
+    # ========================================
+    # RESEARCH METHOD
+    # ========================================
+
+    research_method: Optional[ResearchMethodClassification] = None
 
     # ========================================
     # CONCEPTUAL ANALYSIS

--- a/src/paper_scanner/steps/metadata_extraction.py
+++ b/src/paper_scanner/steps/metadata_extraction.py
@@ -1,0 +1,236 @@
+"""
+LLM-based metadata extraction step.
+
+Uses Claude to extract bibliographic metadata verbatim from papers and classify
+research methods. Updates Paper fields and sets ResearchMethodClassification.
+
+Configuration options:
+  - model: Claude model to use (default: claude-haiku-4-5-20251001)
+  - prompt: Path to prompt template (default: src/prompts/extract-metadata.md)
+  - overwrite: Whether to overwrite existing metadata (default: false)
+
+Environment:
+  - ANTHROPIC_API_KEY: Anthropic API key
+
+Example YAML:
+  - step: "Metadata Extraction"
+    builtin.metadata_extraction:
+      model: "claude-haiku-4-5-20251001"
+      prompt: "src/prompts/extract-metadata.md"
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from paper_scanner.core.enum import StepStatus
+from paper_scanner.core.exceptions import ConfigurationError, StepFatalError
+from paper_scanner.core.models import (
+    Author,
+    Paper,
+    ProcessingMetadata,
+    ResearchMethodClassification,
+)
+from paper_scanner.core.step_result import StepResult
+from paper_scanner.models.anthropic import ClaudeHandler
+
+from .base import BaseStep
+
+logging.getLogger("anthropic").setLevel(logging.WARNING)
+
+DEFAULT_PROMPT_PATH = "src/prompts/extract-metadata.md"
+
+JSON_SCHEMA = """{
+    "title": "string",
+    "authors": [{"given_name": "string", "family_name": "string"}],
+    "abstract": "string",
+    "keywords": ["string"],
+    "year": 2024,
+    "research_method": {
+        "empirical": true,
+        "approach": "quantitative | qualitative | mixed",
+        "industry": "string or null"
+    }
+}"""
+
+
+class MetadataExtractionStep(BaseStep):
+    """LLM-based metadata extraction using Claude."""
+
+    @staticmethod
+    def validate(config: Dict[str, Any]) -> Tuple[bool, List[str]]:
+        errors = []
+
+        if "model" in config and not isinstance(config["model"], str):
+            errors.append("'model' must be a string")
+
+        if "prompt" in config:
+            if not isinstance(config["prompt"], str):
+                errors.append("'prompt' must be a string path")
+            else:
+                prompt_path = Path(config["prompt"])
+                if not prompt_path.exists():
+                    errors.append(f"Prompt file not found: {config['prompt']}")
+
+        if "overwrite" in config and not isinstance(config["overwrite"], bool):
+            errors.append("'overwrite' must be a boolean")
+
+        return len(errors) == 0, errors
+
+    def _load_prompt(self, config: Dict[str, Any]) -> str:
+        """Load and prepare the prompt template."""
+        prompt_path = Path(config.get("prompt", DEFAULT_PROMPT_PATH))
+        if not prompt_path.exists():
+            raise ConfigurationError(f"Prompt file not found: {prompt_path}")
+
+        template = prompt_path.read_text(encoding="utf-8")
+        return template.replace("{json_schema}", JSON_SCHEMA)
+
+    def execute(
+        self,
+        config: Dict[str, Any],
+        verbose: bool = False,
+        dry_run: bool = False,
+        debug: bool = False,
+    ) -> StepResult:
+        model_name = config.get("model", "claude-haiku-4-5-20251001")
+        overwrite = config.get("overwrite", False)
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ConfigurationError("ANTHROPIC_API_KEY environment variable is not set")
+
+        system_prompt = self._load_prompt(config)
+
+        try:
+            claude = ClaudeHandler(api_key=api_key, model=model_name)
+        except Exception as e:
+            raise StepFatalError(f"Failed to initialize ClaudeHandler: {e}", e)
+
+        def predicate(p: Paper) -> bool:
+            if overwrite:
+                return p.title is not None or p.abstract is not None
+            return p.research_method is None
+
+        all_papers = self.db.find(predicate=predicate, primary_only=True)
+        paper_count = len(all_papers)
+
+        stats = {
+            "total_papers": paper_count,
+            "extracted": 0,
+            "skipped": 0,
+            "errors": 0,
+            "total_tokens": 0,
+        }
+
+        if paper_count == 0:
+            return StepResult(
+                status=StepStatus.SUCCESS,
+                message="No papers to extract metadata from",
+                step="metadata_extraction",
+                stats=stats,
+            )
+
+        for i, paper in enumerate(all_papers, 1):
+            if i % 10 == 1:
+                self.callback(f"Extracting metadata {i}/{paper_count}: {paper.cite_key}")
+
+            start_time = datetime.now(timezone.utc)
+
+            paper_text = _format_paper_text(paper)
+            parsed_response, token_usage = claude.call(
+                text=paper_text,
+                system_prompt=system_prompt,
+                max_tokens=2048,
+            )
+
+            if not parsed_response:
+                stats["errors"] += 1
+                continue
+
+            stats["total_tokens"] += token_usage.get("output_tokens", 0)
+
+            if not dry_run:
+                _apply_metadata(paper, parsed_response, model_name, start_time)
+                self.db.update(paper)
+
+            stats["extracted"] += 1
+
+        return StepResult(
+            status=StepStatus.SUCCESS,
+            message=f"Metadata extracted for {stats['extracted']} papers ({stats['errors']} errors)",
+            step="metadata_extraction",
+            stats=stats,
+        )
+
+
+def _format_paper_text(paper: Paper) -> str:
+    """Format paper details for LLM input."""
+    lines = []
+    if paper.title:
+        lines.append(f"TITLE: {paper.title}")
+    if paper.abstract:
+        lines.append(f"ABSTRACT: {paper.abstract}")
+    if paper.keywords:
+        lines.append(f"KEYWORDS: {', '.join(paper.keywords)}")
+    if paper.year:
+        lines.append(f"YEAR: {paper.year}")
+    if paper.authors:
+        author_names = [a.full_name for a in paper.authors[:10]]
+        lines.append(f"AUTHORS: {', '.join(author_names)}")
+    return "\n".join(lines)
+
+
+def _apply_metadata(
+    paper: Paper,
+    response: Dict[str, Any],
+    model_name: str,
+    start_time: datetime,
+) -> None:
+    """Apply extracted metadata to paper model."""
+    metadata = ProcessingMetadata(
+        timestamp=start_time,
+        duration_seconds=(datetime.now(timezone.utc) - start_time).total_seconds(),
+        model_name=model_name,
+        success=True,
+    )
+
+    # Update verbatim fields only if currently missing
+    if not paper.title and response.get("title"):
+        paper.title = response["title"]
+
+    if not paper.abstract and response.get("abstract"):
+        paper.abstract = response["abstract"]
+
+    if not paper.keywords and response.get("keywords"):
+        paper.keywords = response["keywords"]
+
+    if not paper.year and response.get("year"):
+        paper.year = int(response["year"])
+
+    if not paper.authors and response.get("authors"):
+        paper.authors = [
+            Author(
+                given_name=a.get("given_name"),
+                family_name=a.get("family_name", "Unknown"),
+                full_name=f"{a.get('given_name', '')} {a.get('family_name', '')}".strip(),
+            )
+            for a in response["authors"]
+            if isinstance(a, dict)
+        ]
+
+    # Always set research method classification
+    rm = response.get("research_method", {})
+    if isinstance(rm, dict) and "empirical" in rm:
+        approach = rm.get("approach")
+        if approach and approach not in ("quantitative", "qualitative", "mixed"):
+            approach = None
+
+        paper.research_method = ResearchMethodClassification(
+            empirical=bool(rm["empirical"]),
+            approach=approach,
+            industry=rm.get("industry"),
+            metadata=metadata,
+        )

--- a/src/prompts/extract-metadata.md
+++ b/src/prompts/extract-metadata.md
@@ -1,0 +1,23 @@
+You are an expert research librarian. Extract bibliographic metadata from the provided academic paper text. Your task has two parts:
+
+1. **Verbatim extraction** - Extract the following fields exactly as they appear in the paper, without paraphrasing or summarization:
+   - title
+   - authors (as array of objects with given_name and family_name)
+   - abstract
+   - keywords (as array)
+   - year
+
+2. **Research method interpretation** - Based on your reading of the paper, classify:
+   - empirical: Is this an empirical study (based on data/observations) or theoretical/conceptual?
+   - approach: "quantitative", "qualitative", or "mixed"
+   - industry: What industry sector or domain does this research apply to? (e.g., "healthcare", "finance", "manufacturing", "information technology", "education"). Use null if not domain-specific.
+
+Output ONLY valid JSON matching this exact structure:
+
+{json_schema}
+
+Rules:
+- For verbatim fields, preserve the original text exactly. Do not rephrase or summarize.
+- If a field is not available in the paper, use null for strings and empty arrays for lists.
+- For research_method.approach, use only: "quantitative", "qualitative", or "mixed".
+- For research_method.empirical, use true if the paper collects or analyzes data, false if purely theoretical/conceptual.

--- a/tests/unit/steps/test_metadata_extraction.py
+++ b/tests/unit/steps/test_metadata_extraction.py
@@ -1,0 +1,290 @@
+"""Tests for MetadataExtractionStep."""
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from paper_scanner.core.enum import PaperType, StepStatus
+from paper_scanner.core.models import Author, Paper, ResearchMethodClassification
+from paper_scanner.steps.metadata_extraction import (
+    MetadataExtractionStep,
+    _apply_metadata,
+    _format_paper_text,
+)
+
+
+def _make_paper(**kwargs):
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "cite_key": f"test_{uuid.uuid4().hex[:6]}",
+        "title": "Machine Learning in Healthcare",
+        "abstract": "We study ML applications in hospital settings.",
+        "paper_type": PaperType.JOURNAL_ARTICLE,
+        "year": 2024,
+        "authors": [Author(given_name="Jane", family_name="Doe", full_name="Jane Doe")],
+        "keywords": ["machine learning", "healthcare"],
+    }
+    defaults.update(kwargs)
+    return Paper(**defaults)
+
+
+# ============================================================================
+# Validation tests
+# ============================================================================
+
+
+class TestValidate:
+    def test_empty_config_valid(self):
+        is_valid, errors = MetadataExtractionStep.validate({})
+        assert is_valid is True
+        assert errors == []
+
+    def test_invalid_model_type(self):
+        is_valid, errors = MetadataExtractionStep.validate({"model": 123})
+        assert is_valid is False
+        assert any("model" in e for e in errors)
+
+    def test_invalid_prompt_path(self):
+        is_valid, errors = MetadataExtractionStep.validate({"prompt": "/nonexistent/path.md"})
+        assert is_valid is False
+        assert any("not found" in e for e in errors)
+
+    def test_valid_prompt_path(self, tmp_path):
+        prompt = tmp_path / "test.md"
+        prompt.write_text("test prompt")
+        is_valid, errors = MetadataExtractionStep.validate({"prompt": str(prompt)})
+        assert is_valid is True
+
+    def test_invalid_overwrite_type(self):
+        is_valid, errors = MetadataExtractionStep.validate({"overwrite": "yes"})
+        assert is_valid is False
+        assert any("overwrite" in e for e in errors)
+
+
+# ============================================================================
+# Format paper text tests
+# ============================================================================
+
+
+class TestFormatPaperText:
+    def test_formats_all_fields(self):
+        paper = _make_paper()
+        text = _format_paper_text(paper)
+        assert "TITLE: Machine Learning in Healthcare" in text
+        assert "ABSTRACT:" in text
+        assert "KEYWORDS: machine learning, healthcare" in text
+        assert "YEAR: 2024" in text
+        assert "AUTHORS: Jane Doe" in text
+
+    def test_handles_missing_fields(self):
+        paper = _make_paper(title=None, abstract=None, keywords=[], year=None, authors=[])
+        text = _format_paper_text(paper)
+        assert text == ""
+
+
+# ============================================================================
+# Apply metadata tests
+# ============================================================================
+
+
+class TestApplyMetadata:
+    def test_sets_research_method(self):
+        paper = _make_paper()
+        response = {
+            "title": "Machine Learning in Healthcare",
+            "research_method": {
+                "empirical": True,
+                "approach": "quantitative",
+                "industry": "healthcare",
+            },
+        }
+        _apply_metadata(paper, response, "claude-haiku-4-5-20251001", datetime.now(timezone.utc))
+
+        assert paper.research_method is not None
+        assert paper.research_method.empirical is True
+        assert paper.research_method.approach == "quantitative"
+        assert paper.research_method.industry == "healthcare"
+
+    def test_does_not_overwrite_existing_title(self):
+        paper = _make_paper(title="Original Title")
+        response = {"title": "New Title", "research_method": {"empirical": False}}
+        _apply_metadata(paper, response, "test", datetime.now(timezone.utc))
+        assert paper.title == "Original Title"
+
+    def test_fills_missing_title(self):
+        paper = _make_paper(title=None)
+        response = {"title": "Extracted Title", "research_method": {"empirical": False}}
+        _apply_metadata(paper, response, "test", datetime.now(timezone.utc))
+        assert paper.title == "Extracted Title"
+
+    def test_fills_missing_authors(self):
+        paper = _make_paper(authors=[])
+        response = {
+            "authors": [{"given_name": "John", "family_name": "Smith"}],
+            "research_method": {"empirical": True},
+        }
+        _apply_metadata(paper, response, "test", datetime.now(timezone.utc))
+        assert len(paper.authors) == 1
+        assert paper.authors[0].family_name == "Smith"
+
+    def test_rejects_invalid_approach(self):
+        paper = _make_paper()
+        response = {
+            "research_method": {
+                "empirical": True,
+                "approach": "invalid_value",
+                "industry": None,
+            },
+        }
+        _apply_metadata(paper, response, "test", datetime.now(timezone.utc))
+        assert paper.research_method.approach is None
+
+    def test_handles_missing_research_method(self):
+        paper = _make_paper()
+        response = {"title": "Some Title"}
+        _apply_metadata(paper, response, "test", datetime.now(timezone.utc))
+        assert paper.research_method is None
+
+
+# ============================================================================
+# Execute tests (mocked Claude)
+# ============================================================================
+
+
+class TestExecute:
+    @patch("paper_scanner.steps.metadata_extraction.ClaudeHandler")
+    def test_extracts_metadata_for_papers(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+        mock_claude.call.return_value = (
+            {
+                "title": "ML in Healthcare",
+                "authors": [{"given_name": "Jane", "family_name": "Doe"}],
+                "abstract": "Abstract text",
+                "keywords": ["ml"],
+                "year": 2024,
+                "research_method": {
+                    "empirical": True,
+                    "approach": "quantitative",
+                    "industry": "healthcare",
+                },
+            },
+            {"input_tokens": 500, "output_tokens": 200},
+        )
+
+        # Create a prompt file
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test prompt {json_schema}")
+
+        # Set up step
+        from paper_scanner.core.database import PapersDatabase
+
+        db = PapersDatabase()
+        paper = _make_paper(research_method=None)
+        db.add(paper)
+
+        step = MetadataExtractionStep(
+            general_config={},
+            db=db,
+            cache_dir=tmp_path,
+        )
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)})
+
+        assert result.status == StepStatus.SUCCESS
+        assert result.stats["extracted"] == 1
+        assert result.stats["errors"] == 0
+        mock_claude.call.assert_called_once()
+
+    @patch("paper_scanner.steps.metadata_extraction.ClaudeHandler")
+    def test_handles_api_error(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+        mock_claude.call.return_value = (None, {"input_tokens": 0, "output_tokens": 0})
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test prompt {json_schema}")
+
+        from paper_scanner.core.database import PapersDatabase
+
+        db = PapersDatabase()
+        paper = _make_paper(research_method=None)
+        db.add(paper)
+
+        step = MetadataExtractionStep(
+            general_config={},
+            db=db,
+            cache_dir=tmp_path,
+        )
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)})
+
+        assert result.status == StepStatus.SUCCESS
+        assert result.stats["errors"] == 1
+        assert result.stats["extracted"] == 0
+
+    def test_raises_without_api_key(self, tmp_path):
+        from paper_scanner.core.database import PapersDatabase
+
+        step = MetadataExtractionStep(
+            general_config={},
+            db=PapersDatabase(),
+            cache_dir=tmp_path,
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(Exception, match="ANTHROPIC_API_KEY"):
+                step.execute({})
+
+    @patch("paper_scanner.steps.metadata_extraction.ClaudeHandler")
+    def test_no_papers_returns_success(self, mock_claude_class, tmp_path):
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test prompt {json_schema}")
+
+        from paper_scanner.core.database import PapersDatabase
+
+        step = MetadataExtractionStep(
+            general_config={},
+            db=PapersDatabase(),
+            cache_dir=tmp_path,
+        )
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)})
+
+        assert result.status == StepStatus.SUCCESS
+        assert result.stats["total_papers"] == 0
+
+    @patch("paper_scanner.steps.metadata_extraction.ClaudeHandler")
+    def test_dry_run_does_not_persist(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+        mock_claude.call.return_value = (
+            {
+                "research_method": {"empirical": True, "approach": "qualitative", "industry": None},
+            },
+            {"input_tokens": 100, "output_tokens": 50},
+        )
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test prompt {json_schema}")
+
+        from paper_scanner.core.database import PapersDatabase
+
+        db = PapersDatabase()
+        paper = _make_paper(research_method=None)
+        db.add(paper)
+
+        step = MetadataExtractionStep(general_config={}, db=db, cache_dir=tmp_path)
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)}, dry_run=True)
+
+        assert result.stats["extracted"] == 1
+        # Paper should NOT have been updated in db
+        assert paper.research_method is None


### PR DESCRIPTION
## Summary
- Adds `MetadataExtractionStep` that calls Claude to extract bibliographic fields verbatim + classify research methods
- New `ResearchMethodClassification` Pydantic model (empirical, approach, industry)
- External prompt template `src/prompts/extract-metadata.md` per ADR-0001
- Registered in step registry as `metadata_extraction`

Closes #43
Refs: #42

## Test plan
- [x] 18 unit tests covering validation, extraction, error handling, dry-run
- [x] Full test suite passes (2681 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)