### PR TITLE
feat: add relevance scoring step

### DIFF
--- a/src/paper_scanner/cli/__init__.py
+++ b/src/paper_scanner/cli/__init__.py
@@ -19,6 +19,7 @@ STEP_REGISTRY_PATHS: Dict[str, str] = {
     "keyword_screening": "paper_scanner.steps.keyword_screening:KeywordScreeningStep",
     "llm_classification": "paper_scanner.steps.llm_classification:LLMClassificationStep",
     "metadata_extraction": "paper_scanner.steps.metadata_extraction:MetadataExtractionStep",
+    "relevance_scoring": "paper_scanner.steps.relevance_scoring:RelevanceScoringStep",
     "load_files": "paper_scanner.steps.load_files:LoadFilesStep",
     "metadata_screening": "paper_scanner.steps.metadata_screening:MetadataScreeningStep",
     "paper": "paper_scanner.steps.paper:PaperStep",

--- a/src/paper_scanner/core/models.py
+++ b/src/paper_scanner/core/models.py
@@ -397,6 +397,25 @@ class FullPaperScreening(BaseModel):
     metadata: Optional[ProcessingMetadata] = None
 
 # ============================================================================
+# RELEVANCE SCORE MODEL
+# ============================================================================
+
+class RelevanceScore(BaseModel):
+    """Relevance scoring result from LLM analysis."""
+
+    relevance: float = Field(ge=0, le=1, description="How relevant the paper is to the research question")
+    confidence: float = Field(ge=0, le=1, description="Confidence in the relevance assessment")
+    justification: str = Field(description="Brief explanation of the scoring rationale")
+    matching_keywords: List[str] = Field(default_factory=list)
+    research_question_alignment: Optional[str] = Field(
+        default=None,
+        description="How the paper relates to the research question",
+    )
+
+    metadata: Optional[ProcessingMetadata] = None
+
+
+# ============================================================================
 # SCREENING MODEL (aggregates all screening steps)
 # ============================================================================
 
@@ -423,6 +442,9 @@ class Screening(BaseModel):
 
     # Stage 6: Full paper screening (not excluded stages 0-3 means full paper review)
     full_paper_screening: Optional[FullPaperScreening] = None
+
+    # Relevance scoring (from LLM relevance scoring step)
+    relevance_scoring: Optional[RelevanceScore] = None
 
     manual_decision: Optional[ScreeningDecision] = None
     # Final decision (for further processing)

--- a/src/paper_scanner/steps/relevance_scoring.py
+++ b/src/paper_scanner/steps/relevance_scoring.py
@@ -1,0 +1,227 @@
+"""
+LLM-based relevance scoring step.
+
+Uses Claude to score how well each paper fits a given research question
+and keyword set. Produces relevance and confidence scores stored in
+Screening.relevance_scoring.
+
+Configuration options:
+  - model: Claude model to use (default: claude-haiku-4-5-20251001)
+  - prompt: Path to prompt template (default: src/prompts/score-relevance.md)
+
+Environment:
+  - ANTHROPIC_API_KEY: Anthropic API key
+
+Example YAML:
+  - step: "Relevance Scoring"
+    builtin.relevance_scoring:
+      model: "claude-sonnet-4-5-20250929"
+      prompt: "src/prompts/score-relevance.md"
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from paper_scanner.core.enum import StepStatus
+from paper_scanner.core.exceptions import ConfigurationError, StepFatalError
+from paper_scanner.core.models import Paper, ProcessingMetadata, RelevanceScore
+from paper_scanner.core.step_result import StepResult
+from paper_scanner.models.anthropic import ClaudeHandler
+
+from .base import BaseStep
+
+logging.getLogger("anthropic").setLevel(logging.WARNING)
+
+DEFAULT_PROMPT_PATH = "src/prompts/score-relevance.md"
+
+JSON_SCHEMA = """{
+    "relevance": 0.75,
+    "confidence": 0.85,
+    "justification": "string",
+    "matching_keywords": ["keyword1", "keyword2"],
+    "research_question_alignment": "string"
+}"""
+
+
+class RelevanceScoringStep(BaseStep):
+    """LLM-based relevance scoring using Claude."""
+
+    @staticmethod
+    def validate(config: Dict[str, Any]) -> Tuple[bool, List[str]]:
+        errors = []
+
+        if "model" in config and not isinstance(config["model"], str):
+            errors.append("'model' must be a string")
+
+        if "prompt" in config:
+            if not isinstance(config["prompt"], str):
+                errors.append("'prompt' must be a string path")
+            else:
+                prompt_path = Path(config["prompt"])
+                if not prompt_path.exists():
+                    errors.append(f"Prompt file not found: {config['prompt']}")
+
+        return len(errors) == 0, errors
+
+    def _load_prompt(self, config: Dict[str, Any]) -> str:
+        """Load and prepare the prompt template with research question and keywords."""
+        prompt_path = Path(config.get("prompt", DEFAULT_PROMPT_PATH))
+        if not prompt_path.exists():
+            raise ConfigurationError(f"Prompt file not found: {prompt_path}")
+
+        research_question = self.general_config.get("research_question", "")
+        keywords = self.general_config.get("keywords", [])
+        if isinstance(keywords, list):
+            keywords_str = ", ".join(keywords)
+        else:
+            keywords_str = str(keywords)
+
+        template = prompt_path.read_text(encoding="utf-8")
+        return (
+            template
+            .replace("{json_schema}", JSON_SCHEMA)
+            .replace("{research_question}", research_question)
+            .replace("{keywords}", keywords_str)
+        )
+
+    def execute(
+        self,
+        config: Dict[str, Any],
+        verbose: bool = False,
+        dry_run: bool = False,
+        debug: bool = False,
+    ) -> StepResult:
+        model_name = config.get("model", "claude-haiku-4-5-20251001")
+
+        research_question = self.general_config.get("research_question", "")
+        if not research_question:
+            raise ConfigurationError("research_question must be set in project configuration")
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ConfigurationError("ANTHROPIC_API_KEY environment variable is not set")
+
+        system_prompt = self._load_prompt(config)
+
+        try:
+            claude = ClaudeHandler(api_key=api_key, model=model_name)
+        except Exception as e:
+            raise StepFatalError(f"Failed to initialize ClaudeHandler: {e}", e)
+
+        def predicate(p: Paper) -> bool:
+            return p.screening.relevance_scoring is None and not p.is_excluded
+
+        all_papers = self.db.find(predicate=predicate, primary_only=True)
+        paper_count = len(all_papers)
+
+        stats = {
+            "total_papers": paper_count,
+            "scored": 0,
+            "errors": 0,
+            "total_tokens": 0,
+            "avg_relevance": 0.0,
+        }
+
+        if paper_count == 0:
+            return StepResult(
+                status=StepStatus.SUCCESS,
+                message="No papers to score",
+                step="relevance_scoring",
+                stats=stats,
+            )
+
+        relevance_sum = 0.0
+
+        for i, paper in enumerate(all_papers, 1):
+            if i % 10 == 1:
+                self.callback(f"Scoring relevance {i}/{paper_count}: {paper.cite_key}")
+
+            start_time = datetime.now(timezone.utc)
+
+            paper_text = _format_paper_text(paper)
+            parsed_response, token_usage = claude.call(
+                text=paper_text,
+                system_prompt=system_prompt,
+                max_tokens=1024,
+            )
+
+            if not parsed_response:
+                stats["errors"] += 1
+                continue
+
+            stats["total_tokens"] += token_usage.get("output_tokens", 0)
+
+            relevance = _parse_relevance(parsed_response, model_name, start_time)
+            if relevance is None:
+                stats["errors"] += 1
+                continue
+
+            relevance_sum += relevance.relevance
+
+            if not dry_run:
+                paper.screening.relevance_scoring = relevance
+                self.db.update(paper)
+
+            stats["scored"] += 1
+
+        if stats["scored"] > 0:
+            stats["avg_relevance"] = round(relevance_sum / stats["scored"], 3)
+
+        return StepResult(
+            status=StepStatus.SUCCESS,
+            message=f"Scored {stats['scored']} papers (avg relevance: {stats['avg_relevance']}, {stats['errors']} errors)",
+            step="relevance_scoring",
+            stats=stats,
+        )
+
+
+def _format_paper_text(paper: Paper) -> str:
+    """Format paper details for LLM input."""
+    lines = []
+    if paper.title:
+        lines.append(f"TITLE: {paper.title}")
+    if paper.abstract:
+        lines.append(f"ABSTRACT: {paper.abstract}")
+    if paper.keywords:
+        lines.append(f"KEYWORDS: {', '.join(paper.keywords)}")
+    if paper.year:
+        lines.append(f"YEAR: {paper.year}")
+    if paper.authors:
+        author_names = [a.full_name for a in paper.authors[:10]]
+        lines.append(f"AUTHORS: {', '.join(author_names)}")
+    return "\n".join(lines)
+
+
+def _parse_relevance(
+    response: Dict[str, Any],
+    model_name: str,
+    start_time: datetime,
+) -> Optional[RelevanceScore]:
+    """Parse LLM response into a RelevanceScore model."""
+    try:
+        relevance = float(response.get("relevance", -1))
+        confidence = float(response.get("confidence", -1))
+
+        if not (0 <= relevance <= 1) or not (0 <= confidence <= 1):
+            return None
+
+        metadata = ProcessingMetadata(
+            timestamp=start_time,
+            duration_seconds=(datetime.now(timezone.utc) - start_time).total_seconds(),
+            model_name=model_name,
+            success=True,
+        )
+
+        return RelevanceScore(
+            relevance=relevance,
+            confidence=confidence,
+            justification=response.get("justification", ""),
+            matching_keywords=response.get("matching_keywords", []),
+            research_question_alignment=response.get("research_question_alignment"),
+            metadata=metadata,
+        )
+    except (ValueError, TypeError):
+        return None

--- a/src/prompts/score-relevance.md
+++ b/src/prompts/score-relevance.md
@@ -1,0 +1,30 @@
+You are an expert systematic literature review researcher. Your task is to assess how relevant an academic paper is to a specific research question and set of keywords.
+
+RESEARCH QUESTION:
+{research_question}
+
+KEYWORDS:
+{keywords}
+
+Score the paper on two dimensions:
+
+1. **relevance** (0.0 to 1.0): How well does this paper address the research question?
+   - 0.0-0.2: Not relevant — different topic entirely
+   - 0.2-0.4: Tangentially related — shares some terminology but different focus
+   - 0.4-0.6: Partially relevant — addresses related aspects but not the core question
+   - 0.6-0.8: Relevant — directly addresses the research question
+   - 0.8-1.0: Highly relevant — central to the research question
+
+2. **confidence** (0.0 to 1.0): How confident are you in your relevance assessment?
+   - Lower confidence when: abstract is vague, paper could be interpreted multiple ways, insufficient information
+   - Higher confidence when: clear match/mismatch, detailed abstract, explicit methodology
+
+Output ONLY valid JSON matching this exact structure:
+
+{json_schema}
+
+Rules:
+- Be calibrated: a relevance of 0.7 means roughly 7 out of 10 similar papers would be useful.
+- Justify your score in the justification field.
+- List only keywords that actually appear or are strongly implied in the paper.
+- Keep research_question_alignment to 1-2 sentences.

--- a/tests/unit/steps/test_relevance_scoring.py
+++ b/tests/unit/steps/test_relevance_scoring.py
@@ -1,0 +1,275 @@
+"""Tests for RelevanceScoringStep."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from paper_scanner.core.enum import PaperType, ScreeningDecision, StepStatus
+from paper_scanner.core.models import Author, Paper, RelevanceScore
+from paper_scanner.steps.relevance_scoring import (
+    RelevanceScoringStep,
+    _format_paper_text,
+    _parse_relevance,
+)
+
+
+def _make_paper(**kwargs):
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "cite_key": f"test_{uuid.uuid4().hex[:6]}",
+        "title": "Innovation in Supply Chains",
+        "abstract": "We study digital innovation in supply chain management.",
+        "paper_type": PaperType.JOURNAL_ARTICLE,
+        "year": 2023,
+        "authors": [Author(given_name="John", family_name="Smith", full_name="John Smith")],
+        "keywords": ["innovation", "supply chain"],
+    }
+    defaults.update(kwargs)
+    return Paper(**defaults)
+
+
+# ============================================================================
+# Validation tests
+# ============================================================================
+
+
+class TestValidate:
+    def test_empty_config_valid(self):
+        is_valid, errors = RelevanceScoringStep.validate({})
+        assert is_valid is True
+
+    def test_invalid_model_type(self):
+        is_valid, errors = RelevanceScoringStep.validate({"model": 123})
+        assert is_valid is False
+        assert any("model" in e for e in errors)
+
+    def test_invalid_prompt_path(self):
+        is_valid, errors = RelevanceScoringStep.validate({"prompt": "/no/such/file.md"})
+        assert is_valid is False
+
+    def test_valid_prompt(self, tmp_path):
+        p = tmp_path / "prompt.md"
+        p.write_text("test")
+        is_valid, errors = RelevanceScoringStep.validate({"prompt": str(p)})
+        assert is_valid is True
+
+
+# ============================================================================
+# Parse relevance tests
+# ============================================================================
+
+
+class TestParseRelevance:
+    def test_valid_response(self):
+        response = {
+            "relevance": 0.8,
+            "confidence": 0.9,
+            "justification": "Directly addresses the topic",
+            "matching_keywords": ["innovation"],
+            "research_question_alignment": "Strong alignment",
+        }
+        result = _parse_relevance(response, "test-model", datetime.now(timezone.utc))
+        assert result is not None
+        assert result.relevance == 0.8
+        assert result.confidence == 0.9
+        assert result.justification == "Directly addresses the topic"
+
+    def test_out_of_range_relevance(self):
+        response = {"relevance": 1.5, "confidence": 0.5, "justification": ""}
+        result = _parse_relevance(response, "test", datetime.now(timezone.utc))
+        assert result is None
+
+    def test_out_of_range_confidence(self):
+        response = {"relevance": 0.5, "confidence": -0.1, "justification": ""}
+        result = _parse_relevance(response, "test", datetime.now(timezone.utc))
+        assert result is None
+
+    def test_missing_relevance(self):
+        response = {"confidence": 0.5, "justification": ""}
+        result = _parse_relevance(response, "test", datetime.now(timezone.utc))
+        assert result is None
+
+    def test_non_numeric_values(self):
+        response = {"relevance": "high", "confidence": "low", "justification": ""}
+        result = _parse_relevance(response, "test", datetime.now(timezone.utc))
+        assert result is None
+
+    def test_boundary_values(self):
+        response = {"relevance": 0.0, "confidence": 1.0, "justification": "Edge case"}
+        result = _parse_relevance(response, "test", datetime.now(timezone.utc))
+        assert result is not None
+        assert result.relevance == 0.0
+        assert result.confidence == 1.0
+
+
+# ============================================================================
+# Format paper text tests
+# ============================================================================
+
+
+class TestFormatPaperText:
+    def test_formats_all_fields(self):
+        paper = _make_paper()
+        text = _format_paper_text(paper)
+        assert "TITLE:" in text
+        assert "ABSTRACT:" in text
+        assert "KEYWORDS:" in text
+
+    def test_handles_empty_paper(self):
+        paper = _make_paper(title=None, abstract=None, keywords=[], year=None, authors=[])
+        text = _format_paper_text(paper)
+        assert text == ""
+
+
+# ============================================================================
+# Execute tests (mocked Claude)
+# ============================================================================
+
+
+class TestExecute:
+    @patch("paper_scanner.steps.relevance_scoring.ClaudeHandler")
+    def test_scores_papers(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+        mock_claude.call.return_value = (
+            {
+                "relevance": 0.85,
+                "confidence": 0.92,
+                "justification": "Directly addresses supply chain innovation",
+                "matching_keywords": ["innovation", "supply chain"],
+                "research_question_alignment": "Strong alignment with RQ",
+            },
+            {"input_tokens": 400, "output_tokens": 150},
+        )
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test {json_schema} {research_question} {keywords}")
+
+        from paper_scanner.core.database import PapersDatabase
+
+        db = PapersDatabase()
+        paper = _make_paper()
+        db.add(paper)
+
+        step = RelevanceScoringStep(
+            general_config={
+                "research_question": "How does digital innovation affect supply chains?",
+                "keywords": ["innovation", "digital", "supply chain"],
+            },
+            db=db,
+            cache_dir=tmp_path,
+        )
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)})
+
+        assert result.status == StepStatus.SUCCESS
+        assert result.stats["scored"] == 1
+        assert result.stats["avg_relevance"] == 0.85
+        # Verify paper was updated
+        assert paper.screening.relevance_scoring is not None
+        assert paper.screening.relevance_scoring.relevance == 0.85
+
+    @patch("paper_scanner.steps.relevance_scoring.ClaudeHandler")
+    def test_skips_excluded_papers(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test {json_schema} {research_question} {keywords}")
+
+        from paper_scanner.core.database import PapersDatabase
+
+        db = PapersDatabase()
+        paper = _make_paper()
+        paper.screening.final_decision = ScreeningDecision.EXCLUDED
+        db.add(paper)
+
+        step = RelevanceScoringStep(
+            general_config={"research_question": "Test RQ", "keywords": []},
+            db=db,
+            cache_dir=tmp_path,
+        )
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)})
+
+        assert result.stats["total_papers"] == 0
+        mock_claude.call.assert_not_called()
+
+    @patch("paper_scanner.steps.relevance_scoring.ClaudeHandler")
+    def test_handles_api_failure(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+        mock_claude.call.return_value = (None, {"input_tokens": 0, "output_tokens": 0})
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test {json_schema} {research_question} {keywords}")
+
+        from paper_scanner.core.database import PapersDatabase
+
+        db = PapersDatabase()
+        db.add(_make_paper())
+
+        step = RelevanceScoringStep(
+            general_config={"research_question": "Test", "keywords": []},
+            db=db,
+            cache_dir=tmp_path,
+        )
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)})
+
+        assert result.stats["errors"] == 1
+        assert result.stats["scored"] == 0
+
+    def test_raises_without_research_question(self, tmp_path):
+        from paper_scanner.core.database import PapersDatabase
+
+        step = RelevanceScoringStep(
+            general_config={},
+            db=PapersDatabase(),
+            cache_dir=tmp_path,
+        )
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            with pytest.raises(Exception, match="research_question"):
+                step.execute({})
+
+    @patch("paper_scanner.steps.relevance_scoring.ClaudeHandler")
+    def test_dry_run_does_not_persist(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+        mock_claude.call.return_value = (
+            {
+                "relevance": 0.7,
+                "confidence": 0.8,
+                "justification": "Relevant",
+                "matching_keywords": [],
+                "research_question_alignment": "Aligned",
+            },
+            {"input_tokens": 100, "output_tokens": 50},
+        )
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test {json_schema} {research_question} {keywords}")
+
+        from paper_scanner.core.database import PapersDatabase
+
+        db = PapersDatabase()
+        paper = _make_paper()
+        db.add(paper)
+
+        step = RelevanceScoringStep(
+            general_config={"research_question": "Test", "keywords": []},
+            db=db,
+            cache_dir=tmp_path,
+        )
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)}, dry_run=True)
+
+        assert result.stats["scored"] == 1
+        assert paper.screening.relevance_scoring is None


### PR DESCRIPTION
## Summary
- Adds `RelevanceScoringStep` that calls Claude to score paper relevance (0-1) and confidence (0-1) against a research question + keywords
- New `RelevanceScore` Pydantic model with justification and keyword matching
- New field `Screening.relevance_scoring` for downstream filtering (#46)
- External prompt template `src/prompts/score-relevance.md` per ADR-0001

Closes #44
Refs: #42, #46

## Test plan
- [x] 17 unit tests covering validation, parsing, execution, dry-run, error handling
- [x] Full test suite passes (2680 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)