### PR TITLE
feat: add CAMO statement extraction step

### DIFF
--- a/src/paper_scanner/cli/__init__.py
+++ b/src/paper_scanner/cli/__init__.py
@@ -5,6 +5,7 @@ from typing import Dict
 # Map step names to module paths for lazy loading
 STEP_REGISTRY_PATHS: Dict[str, str] = {
     "bibtex_import": "paper_scanner.steps.bibtex_import:BibtexImportStep",
+    "camo_extraction": "paper_scanner.steps.camo_extraction:CAMOExtractionStep",
     "checkpoint": "paper_scanner.steps.checkpoint:CheckpointStep",
     "citations": "paper_scanner.steps.citations:CitationsStep",
     "deduplication": "paper_scanner.steps.deduplication:DeduplicationStep",

--- a/src/paper_scanner/steps/camo_extraction.py
+++ b/src/paper_scanner/steps/camo_extraction.py
@@ -1,0 +1,252 @@
+"""
+LLM-based CAMO statement extraction step.
+
+Uses Claude to extract Context-Agency-Mechanism-Outcome statements from
+academic papers. Results are stored in Paper.conceptual_analysis.
+
+Configuration options:
+  - model: Claude model to use (default: claude-sonnet-4-5-20250929)
+  - prompt: Path to prompt template (default: src/prompts/extract-camo.md)
+
+Environment:
+  - ANTHROPIC_API_KEY: Anthropic API key
+
+Example YAML:
+  - step: "CAMO Extraction"
+    builtin.camo_extraction:
+      model: "claude-sonnet-4-5-20250929"
+      prompt: "src/prompts/extract-camo.md"
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from paper_scanner.core.enum import StepStatus
+from paper_scanner.core.exceptions import ConfigurationError, StepFatalError
+from paper_scanner.core.models import (
+    CAMOStatement,
+    ConceptualAnalysis,
+    Paper,
+    ProcessingMetadata,
+)
+from paper_scanner.core.step_result import StepResult
+from paper_scanner.models.anthropic import ClaudeHandler
+
+from .base import BaseStep
+
+logging.getLogger("anthropic").setLevel(logging.WARNING)
+
+DEFAULT_PROMPT_PATH = "src/prompts/extract-camo.md"
+
+JSON_SCHEMA = """{
+    "camo_statements": [
+        {
+            "context": "string",
+            "agency": "string",
+            "mechanism": "string",
+            "outcome": "string",
+            "full_statement": "string",
+            "confidence": 0.85,
+            "innovation_type": "string or null",
+            "it_suppliers": ["string"],
+            "regular_suppliers": ["string"]
+        }
+    ]
+}"""
+
+
+class CAMOExtractionStep(BaseStep):
+    """LLM-based CAMO statement extraction using Claude."""
+
+    @staticmethod
+    def validate(config: Dict[str, Any]) -> Tuple[bool, List[str]]:
+        errors = []
+
+        if "model" in config and not isinstance(config["model"], str):
+            errors.append("'model' must be a string")
+
+        if "prompt" in config:
+            if not isinstance(config["prompt"], str):
+                errors.append("'prompt' must be a string path")
+            else:
+                prompt_path = Path(config["prompt"])
+                if not prompt_path.exists():
+                    errors.append(f"Prompt file not found: {config['prompt']}")
+
+        return len(errors) == 0, errors
+
+    def _load_prompt(self, config: Dict[str, Any]) -> str:
+        """Load and prepare the prompt template."""
+        prompt_path = Path(config.get("prompt", DEFAULT_PROMPT_PATH))
+        if not prompt_path.exists():
+            raise ConfigurationError(f"Prompt file not found: {prompt_path}")
+
+        template = prompt_path.read_text(encoding="utf-8")
+        return template.replace("{json_schema}", JSON_SCHEMA)
+
+    def execute(
+        self,
+        config: Dict[str, Any],
+        verbose: bool = False,
+        dry_run: bool = False,
+        debug: bool = False,
+    ) -> StepResult:
+        model_name = config.get("model", "claude-sonnet-4-5-20250929")
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ConfigurationError("ANTHROPIC_API_KEY environment variable is not set")
+
+        system_prompt = self._load_prompt(config)
+
+        try:
+            claude = ClaudeHandler(api_key=api_key, model=model_name)
+        except Exception as e:
+            raise StepFatalError(f"Failed to initialize ClaudeHandler: {e}", e)
+
+        def predicate(p: Paper) -> bool:
+            return p.is_included and (
+                p.conceptual_analysis is None
+                or len(p.conceptual_analysis.camo_statements) == 0
+            )
+
+        all_papers = self.db.find(predicate=predicate, primary_only=True)
+        paper_count = len(all_papers)
+
+        stats = {
+            "total_papers": paper_count,
+            "extracted": 0,
+            "total_statements": 0,
+            "errors": 0,
+            "total_tokens": 0,
+        }
+
+        if paper_count == 0:
+            return StepResult(
+                status=StepStatus.SUCCESS,
+                message="No papers to extract CAMO statements from",
+                step="camo_extraction",
+                stats=stats,
+            )
+
+        for i, paper in enumerate(all_papers, 1):
+            if i % 10 == 1:
+                self.callback(f"Extracting CAMO {i}/{paper_count}: {paper.cite_key}")
+
+            start_time = datetime.now(timezone.utc)
+
+            paper_text = _format_paper_text(paper)
+            parsed_response, token_usage = claude.call(
+                text=paper_text,
+                system_prompt=system_prompt,
+                max_tokens=4096,
+            )
+
+            if not parsed_response:
+                stats["errors"] += 1
+                continue
+
+            stats["total_tokens"] += token_usage.get("output_tokens", 0)
+
+            statements = _parse_camo_statements(parsed_response, model_name, start_time)
+
+            if not dry_run:
+                if paper.conceptual_analysis is None:
+                    paper.conceptual_analysis = ConceptualAnalysis()
+
+                paper.conceptual_analysis.camo_statements = statements
+                paper.conceptual_analysis.metadata = ProcessingMetadata(
+                    timestamp=start_time,
+                    duration_seconds=(datetime.now(timezone.utc) - start_time).total_seconds(),
+                    model_name=model_name,
+                    success=True,
+                )
+                self.db.update(paper)
+
+            stats["extracted"] += 1
+            stats["total_statements"] += len(statements)
+
+        avg = round(stats["total_statements"] / max(stats["extracted"], 1), 1)
+        return StepResult(
+            status=StepStatus.SUCCESS,
+            message=(
+                f"CAMO extraction: {stats['extracted']} papers, "
+                f"{stats['total_statements']} statements (avg {avg}/paper, "
+                f"{stats['errors']} errors)"
+            ),
+            step="camo_extraction",
+            stats=stats,
+        )
+
+
+def _format_paper_text(paper: Paper) -> str:
+    """Format paper details for LLM input."""
+    lines = []
+    if paper.title:
+        lines.append(f"TITLE: {paper.title}")
+    if paper.abstract:
+        lines.append(f"ABSTRACT: {paper.abstract}")
+    if paper.keywords:
+        lines.append(f"KEYWORDS: {', '.join(paper.keywords)}")
+    if paper.year:
+        lines.append(f"YEAR: {paper.year}")
+    if paper.authors:
+        author_names = [a.full_name for a in paper.authors[:10]]
+        lines.append(f"AUTHORS: {', '.join(author_names)}")
+    return "\n".join(lines)
+
+
+def _parse_camo_statements(
+    response: Dict[str, Any],
+    model_name: str,
+    start_time: datetime,
+) -> List[CAMOStatement]:
+    """Parse LLM response into CAMOStatement models."""
+    raw_statements = response.get("camo_statements", [])
+    if not isinstance(raw_statements, list):
+        return []
+
+    metadata = ProcessingMetadata(
+        timestamp=start_time,
+        duration_seconds=(datetime.now(timezone.utc) - start_time).total_seconds(),
+        model_name=model_name,
+        success=True,
+    )
+
+    statements = []
+    for raw in raw_statements:
+        if not isinstance(raw, dict):
+            continue
+
+        # All four CAMO components are required
+        context = raw.get("context", "")
+        agency = raw.get("agency", "")
+        mechanism = raw.get("mechanism", "")
+        outcome = raw.get("outcome", "")
+
+        if not all([context, agency, mechanism, outcome]):
+            continue
+
+        confidence = raw.get("confidence", 0.5)
+        try:
+            confidence = max(0.0, min(1.0, float(confidence)))
+        except (ValueError, TypeError):
+            confidence = 0.5
+
+        statements.append(CAMOStatement(
+            context=context,
+            agency=agency,
+            mechanism=mechanism,
+            outcome=outcome,
+            full_statement=raw.get("full_statement", f"{context} {agency} {mechanism} {outcome}"),
+            confidence=confidence,
+            innovation_type=raw.get("innovation_type"),
+            it_suppliers=raw.get("it_suppliers", []),
+            regular_suppliers=raw.get("regular_suppliers", []),
+            metadata=metadata,
+        ))
+
+    return statements

--- a/src/prompts/extract-camo.md
+++ b/src/prompts/extract-camo.md
@@ -1,0 +1,27 @@
+You are an expert in innovation management research. Your task is to extract Context-Agency-Mechanism-Outcome (CAMO) statements from academic papers.
+
+A CAMO statement describes an innovation mechanism:
+- **Context (C)**: The environment, conditions, or setting in which the innovation occurs
+- **Agency (A)**: The actors, organizations, or entities driving the innovation
+- **Mechanism (M)**: The process, method, or approach through which innovation happens
+- **Outcome (O)**: The results, effects, or consequences of the innovation mechanism
+
+For each CAMO statement, also identify:
+- **confidence**: How confident you are in this extraction (0.0-1.0)
+- **innovation_type**: Type of innovation (e.g., "product", "process", "business model", "organizational", "technological")
+- **it_suppliers**: IT vendors or technology suppliers mentioned (empty array if none)
+- **regular_suppliers**: Non-IT suppliers mentioned (empty array if none)
+- **full_statement**: A synthesized narrative combining all four CAMO components
+
+Extract ALL distinct CAMO statements from the paper. A single paper may contain multiple mechanisms.
+
+Output ONLY valid JSON matching this exact structure:
+
+{json_schema}
+
+Rules:
+- Extract only statements supported by the paper's text. Do not infer beyond what is stated.
+- Each CAMO component should be 1-3 sentences.
+- The full_statement should read as a coherent paragraph synthesizing all components.
+- Set confidence lower when the mechanism is implicit rather than explicitly stated.
+- Return an empty array if no CAMO statements can be extracted.

--- a/tests/unit/steps/test_camo_extraction.py
+++ b/tests/unit/steps/test_camo_extraction.py
@@ -1,0 +1,325 @@
+"""Tests for CAMOExtractionStep."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from paper_scanner.core.database import PapersDatabase
+from paper_scanner.core.enum import PaperType, ScreeningDecision, StepStatus
+from paper_scanner.core.models import Author, ConceptualAnalysis, Paper
+from paper_scanner.steps.camo_extraction import (
+    CAMOExtractionStep,
+    _format_paper_text,
+    _parse_camo_statements,
+)
+
+
+def _make_paper(included=True, **kwargs):
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "cite_key": f"test_{uuid.uuid4().hex[:6]}",
+        "title": "Digital Innovation in Manufacturing",
+        "abstract": "We study how manufacturers adopt digital platforms.",
+        "paper_type": PaperType.JOURNAL_ARTICLE,
+        "year": 2023,
+        "authors": [Author(given_name="Alice", family_name="Chen", full_name="Alice Chen")],
+        "keywords": ["digital innovation", "manufacturing"],
+    }
+    defaults.update(kwargs)
+    paper = Paper(**defaults)
+    if included:
+        paper.screening.final_decision = ScreeningDecision.INCLUDED
+    return paper
+
+
+SAMPLE_RESPONSE = {
+    "camo_statements": [
+        {
+            "context": "Manufacturing firms facing digital transformation",
+            "agency": "IT departments and external consultants",
+            "mechanism": "Adoption of cloud-based ERP systems",
+            "outcome": "Improved operational efficiency and reduced costs",
+            "full_statement": "Manufacturing firms facing digital transformation engaged IT departments and external consultants to adopt cloud-based ERP systems, resulting in improved operational efficiency.",
+            "confidence": 0.85,
+            "innovation_type": "process",
+            "it_suppliers": ["SAP", "Oracle"],
+            "regular_suppliers": [],
+        },
+        {
+            "context": "Supply chain coordination challenges",
+            "agency": "Supply chain managers",
+            "mechanism": "Implementation of blockchain-based tracking",
+            "outcome": "Enhanced transparency and trust among partners",
+            "full_statement": "Supply chain managers implemented blockchain-based tracking to address coordination challenges, enhancing transparency and trust.",
+            "confidence": 0.72,
+            "innovation_type": "technological",
+            "it_suppliers": ["IBM"],
+            "regular_suppliers": ["Maersk"],
+        },
+    ]
+}
+
+
+# ============================================================================
+# Validation tests
+# ============================================================================
+
+
+class TestValidate:
+    def test_empty_config(self):
+        is_valid, errors = CAMOExtractionStep.validate({})
+        assert is_valid is True
+
+    def test_invalid_model_type(self):
+        is_valid, errors = CAMOExtractionStep.validate({"model": 123})
+        assert is_valid is False
+
+    def test_invalid_prompt_path(self):
+        is_valid, errors = CAMOExtractionStep.validate({"prompt": "/no/such.md"})
+        assert is_valid is False
+
+    def test_valid_prompt(self, tmp_path):
+        p = tmp_path / "prompt.md"
+        p.write_text("test")
+        is_valid, errors = CAMOExtractionStep.validate({"prompt": str(p)})
+        assert is_valid is True
+
+
+# ============================================================================
+# Parse CAMO statements tests
+# ============================================================================
+
+
+class TestParseCamoStatements:
+    def test_parses_valid_statements(self):
+        statements = _parse_camo_statements(SAMPLE_RESPONSE, "test", datetime.now(timezone.utc))
+        assert len(statements) == 2
+        assert statements[0].context == "Manufacturing firms facing digital transformation"
+        assert statements[0].mechanism == "Adoption of cloud-based ERP systems"
+        assert statements[0].confidence == 0.85
+        assert statements[0].it_suppliers == ["SAP", "Oracle"]
+        assert statements[1].innovation_type == "technological"
+
+    def test_skips_incomplete_statements(self):
+        response = {
+            "camo_statements": [
+                {"context": "Some context", "agency": "", "mechanism": "Something", "outcome": "Result"},
+            ]
+        }
+        statements = _parse_camo_statements(response, "test", datetime.now(timezone.utc))
+        assert len(statements) == 0  # agency is empty string
+
+    def test_handles_empty_array(self):
+        response = {"camo_statements": []}
+        statements = _parse_camo_statements(response, "test", datetime.now(timezone.utc))
+        assert len(statements) == 0
+
+    def test_handles_missing_key(self):
+        response = {}
+        statements = _parse_camo_statements(response, "test", datetime.now(timezone.utc))
+        assert len(statements) == 0
+
+    def test_handles_non_list(self):
+        response = {"camo_statements": "invalid"}
+        statements = _parse_camo_statements(response, "test", datetime.now(timezone.utc))
+        assert len(statements) == 0
+
+    def test_clamps_confidence(self):
+        response = {
+            "camo_statements": [
+                {
+                    "context": "C",
+                    "agency": "A",
+                    "mechanism": "M",
+                    "outcome": "O",
+                    "confidence": 1.5,
+                }
+            ]
+        }
+        statements = _parse_camo_statements(response, "test", datetime.now(timezone.utc))
+        assert len(statements) == 1
+        assert statements[0].confidence == 1.0
+
+    def test_handles_non_numeric_confidence(self):
+        response = {
+            "camo_statements": [
+                {
+                    "context": "C",
+                    "agency": "A",
+                    "mechanism": "M",
+                    "outcome": "O",
+                    "confidence": "high",
+                }
+            ]
+        }
+        statements = _parse_camo_statements(response, "test", datetime.now(timezone.utc))
+        assert len(statements) == 1
+        assert statements[0].confidence == 0.5  # default
+
+    def test_generates_full_statement_if_missing(self):
+        response = {
+            "camo_statements": [
+                {"context": "C", "agency": "A", "mechanism": "M", "outcome": "O"}
+            ]
+        }
+        statements = _parse_camo_statements(response, "test", datetime.now(timezone.utc))
+        assert statements[0].full_statement == "C A M O"
+
+    def test_skips_non_dict_items(self):
+        response = {"camo_statements": ["not a dict", 42, None]}
+        statements = _parse_camo_statements(response, "test", datetime.now(timezone.utc))
+        assert len(statements) == 0
+
+
+# ============================================================================
+# Format paper text tests
+# ============================================================================
+
+
+class TestFormatPaperText:
+    def test_formats_all_fields(self):
+        paper = _make_paper()
+        text = _format_paper_text(paper)
+        assert "TITLE:" in text
+        assert "ABSTRACT:" in text
+
+    def test_handles_empty_paper(self):
+        paper = _make_paper(title=None, abstract=None, keywords=[], year=None, authors=[])
+        text = _format_paper_text(paper)
+        assert text == ""
+
+
+# ============================================================================
+# Execute tests (mocked Claude)
+# ============================================================================
+
+
+class TestExecute:
+    @patch("paper_scanner.steps.camo_extraction.ClaudeHandler")
+    def test_extracts_camo_statements(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+        mock_claude.call.return_value = (
+            SAMPLE_RESPONSE,
+            {"input_tokens": 1000, "output_tokens": 500},
+        )
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test {json_schema}")
+
+        db = PapersDatabase()
+        paper = _make_paper()
+        db.add(paper)
+
+        step = CAMOExtractionStep(general_config={}, db=db, cache_dir=tmp_path)
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)})
+
+        assert result.status == StepStatus.SUCCESS
+        assert result.stats["extracted"] == 1
+        assert result.stats["total_statements"] == 2
+        assert paper.conceptual_analysis is not None
+        assert len(paper.conceptual_analysis.camo_statements) == 2
+
+    @patch("paper_scanner.steps.camo_extraction.ClaudeHandler")
+    def test_skips_non_included_papers(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test {json_schema}")
+
+        db = PapersDatabase()
+        paper = _make_paper(included=False)
+        db.add(paper)
+
+        step = CAMOExtractionStep(general_config={}, db=db, cache_dir=tmp_path)
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)})
+
+        assert result.stats["total_papers"] == 0
+        mock_claude.call.assert_not_called()
+
+    @patch("paper_scanner.steps.camo_extraction.ClaudeHandler")
+    def test_skips_papers_with_existing_camo(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test {json_schema}")
+
+        db = PapersDatabase()
+        paper = _make_paper()
+        from paper_scanner.core.models import CAMOStatement
+
+        paper.conceptual_analysis = ConceptualAnalysis(
+            camo_statements=[
+                CAMOStatement(
+                    context="C", agency="A", mechanism="M", outcome="O",
+                    full_statement="Existing", confidence=0.9,
+                )
+            ]
+        )
+        db.add(paper)
+
+        step = CAMOExtractionStep(general_config={}, db=db, cache_dir=tmp_path)
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)})
+
+        assert result.stats["total_papers"] == 0
+
+    @patch("paper_scanner.steps.camo_extraction.ClaudeHandler")
+    def test_handles_api_failure(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+        mock_claude.call.return_value = (None, {"input_tokens": 0, "output_tokens": 0})
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test {json_schema}")
+
+        db = PapersDatabase()
+        db.add(_make_paper())
+
+        step = CAMOExtractionStep(general_config={}, db=db, cache_dir=tmp_path)
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)})
+
+        assert result.stats["errors"] == 1
+        assert result.stats["extracted"] == 0
+
+    @patch("paper_scanner.steps.camo_extraction.ClaudeHandler")
+    def test_dry_run_does_not_persist(self, mock_claude_class, tmp_path):
+        mock_claude = MagicMock()
+        mock_claude_class.return_value = mock_claude
+        mock_claude.call.return_value = (
+            SAMPLE_RESPONSE,
+            {"input_tokens": 500, "output_tokens": 250},
+        )
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Test {json_schema}")
+
+        db = PapersDatabase()
+        paper = _make_paper()
+        db.add(paper)
+
+        step = CAMOExtractionStep(general_config={}, db=db, cache_dir=tmp_path)
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            result = step.execute({"prompt": str(prompt_file)}, dry_run=True)
+
+        assert result.stats["extracted"] == 1
+        assert paper.conceptual_analysis is None
+
+    def test_raises_without_api_key(self, tmp_path):
+        step = CAMOExtractionStep(general_config={}, db=PapersDatabase(), cache_dir=tmp_path)
+
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(Exception, match="ANTHROPIC_API_KEY"):
+                step.execute({})


### PR DESCRIPTION
## Summary
- Adds `CAMOExtractionStep` that calls Claude to extract structured Context-Agency-Mechanism-Outcome statements
- Uses existing `CAMOStatement` and `ConceptualAnalysis` Pydantic models
- Only processes included papers (runs after relevance filtering)
- External prompt template `src/prompts/extract-camo.md` per ADR-0001
- Default model: sonnet (deeper reasoning needed for CAMO analysis)

Closes #45
Refs: #42

## Test plan
- [x] 21 unit tests covering parsing, validation, execution, dry-run, error handling
- [x] Full test suite passes (2684 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)